### PR TITLE
Add support for 8bitDo Micro in keyboard mode

### DIFF
--- a/examples/8bitDo Micro gamepad
+++ b/examples/8bitDo Micro gamepad
@@ -1,0 +1,4 @@
+prevPage EV_KEY KEY_I 0
+nextPage EV_KEY KEY_G 0
+prevPage EV_KEY KEY_F 0
+nextPage EV_KEY KEY_E 0


### PR DESCRIPTION
Hey,
I've added an example config file for an 8BitDo Micro controller in keyboard mode that I just got working on my Kobo Sage. It is set to work in both vertical directions so that 'left' and 'A' serve as page forward and 'down' and 'Y' are page back