### PR TITLE
Allow support of comments in example file

### DIFF
--- a/examples/AB Shutter3
+++ b/examples/AB Shutter3
@@ -1,0 +1,12 @@
+# Format:
+# METHOD  TYPE  CODE  VALUE
+#
+# COLUMN DEFINITIONS:
+# 1. METHOD:    The internal Kobo function to call.
+# 2. TYPE:      The Linux Input Event Type. Usually 'EV_KEY' for buttons or 'EV_ABS' for joysticks.
+# 3. CODE:      The specific button code. Examples: KEY_VOLUMEUP, KEY_VOLUMEDOWN, BTN_A, BTN_B
+# 4. VALUE:     The state of the button.
+#               1 = Press (Trigger immediately when button goes down)
+#               0 = Release (Trigger when button is let go)
+# ------------------------------------------------------------------------------
+nextPage EV_KEY KEY_VOLUMEUP 0

--- a/src/btpt.cc
+++ b/src/btpt.cc
@@ -119,6 +119,19 @@ bool BluetoothPageTurner::addDevice(
 		 */
 
 		QString line = in.readLine();
+
+        /* Support for Comments */
+        /* Remove anything after a '#' character */
+        line = line.section('#', 0, 0);
+
+        /* Remove whitespace from start and end */
+        line = line.trimmed();
+
+        /* If line is now empty, skip it */
+        if (line.isEmpty()) {
+            continue;
+        }
+
 		QList<QString> parts = line.split(" ", QString::SkipEmptyParts);
 		if (parts.size() != 4) {
 			nh_log("invalid config line: %s",


### PR DESCRIPTION
Adding support in config parser to allow comments, making it much easier to document mappings.

Additionally adding `examples/AB Shutter3` with comments.

This type of bluetooth camera shutter button shows up as `AB Shutter3`.
<img src="https://m.media-amazon.com/images/I/617T65docCL._AC_SL1500_.jpg" width="200" alt="AB Shutter3">